### PR TITLE
respects cfn-lint config

### DIFF
--- a/cfn_lsp_extra/cfnlint_integration.py
+++ b/cfn_lsp_extra/cfnlint_integration.py
@@ -32,6 +32,21 @@ def diagnostics(yaml_content: str, file_path: str) -> List[Diagnostic]:
     regions = ["us-east-1"]
 
     if not errors:
+        try:
+            (config, _, _) = cfnlint.core.get_args_filenames(file_path)
+            # override rules with config-specific rules
+            rules = cfnlint.core.get_rules(
+                config.append_rules,
+                config.ignore_checks,
+                config.include_checks,
+                config.configure_rules,
+                config.include_experimental,
+                config.mandatory_checks,
+                config.custom_rules,
+            )
+        except Exception:
+            # ignore errors, use all rules as defined above instead
+            pass
         runner = cfnlint.runner.Runner(
             rules, file_path, template, regions=regions, mandatory_rules=None
         )

--- a/cfn_lsp_extra/cfnlint_integration.py
+++ b/cfn_lsp_extra/cfnlint_integration.py
@@ -33,7 +33,7 @@ def diagnostics(yaml_content: str, file_path: str) -> List[Diagnostic]:
 
     if not errors:
         try:
-            (config, _, _) = cfnlint.core.get_args_filenames(file_path)
+            config = cfnlint.config.ConfigMixIn(file_path)
             # override rules with config-specific rules
             rules = cfnlint.core.get_rules(
                 config.append_rules,
@@ -45,7 +45,7 @@ def diagnostics(yaml_content: str, file_path: str) -> List[Diagnostic]:
                 config.custom_rules,
             )
         except Exception:
-            # ignore errors, use all rules as defined above instead
+            # ignore errors, use all rules as defined above in the first get_rules instead
             pass
         runner = cfnlint.runner.Runner(
             rules, file_path, template, regions=regions, mandatory_rules=None


### PR DESCRIPTION
I found an issue that my `.cfnlintrc.yml` file was not being respected, resulting in the LSP returning diagnostics for things I'd like to ignore (that are ignored by running the `cfn-lint` CLI)

Looking through how cfn-lint handles this, I passed added the same function calls to source cfn-lint's config and pass them to `get_rules`

I added this in a non-breaking manner just in case I'm missing something, but am more than happy to reduce it to one function call or shuffle anything else around. It seems to work so far with my setup