### PR TITLE
fix: neovim config

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,15 +61,15 @@ vim.filetype.add {
     ['.*'] = {
       priority = math.huge,
       function(path, bufnr)
-        local line1 = vim.filetype.getlines(bufnr, 1)
-        local line2 = vim.filetype.getlines(bufnr, 2)
-        if vim.filetype.matchregex(line1, [[^AWSTemplateFormatVersion]] ) or
-           vim.filetype.matchregex(line1, [[AWS::Serverless-2016-10-31]] ) then
+        local line1 = vim.api.nvim_buf_get_lines(bufnr, 0, 1, false)[1] or ""
+        local line2 = vim.api.nvim_buf_get_lines(bufnr, 1, 2, false)[1] or ""
+        if vim.regex([[^AWSTemplateFormatVersion]]):match_str(line1) ~= nil or
+           vim.regex([[AWS::Serverless-2016-10-31]]):match_str(line1) ~= nil then
           return 'yaml.cloudformation'
-        elseif vim.filetype.matchregex(line1, [[["']AWSTemplateFormatVersion]] ) or
-           vim.filetype.matchregex(line2, [[["']AWSTemplateFormatVersion]] ) or
-           vim.filetype.matchregex(line1, [[AWS::Serverless-2016-10-31]] ) or
-           vim.filetype.matchregex(line2, [[AWS::Serverless-2016-10-31]] ) then
+        elseif vim.regex([[["']AWSTemplateFormatVersion]]):match_str(line1) ~= nil or
+           vim.regex([[["']AWSTemplateFormatVersion]]):match_str(line2) ~= nil or
+           vim.regex([[AWS::Serverless-2016-10-31]]):match_str(line1) ~= nil or
+           vim.regex([[AWS::Serverless-2016-10-31]]):match_str(line2) ~= nil then
           return 'json.cloudformation'
         end
       end,


### PR DESCRIPTION
As it uses private functions (vim.filetype.getlines and vim.filetype.matchregex) that are no more available.

See also: https://github.com/neovim/neovim/pull/24573

And thanks for the repo, for the moment, this works really well :tada: 